### PR TITLE
Fix for audio breaking after a certain time into the stream

### DIFF
--- a/player/src/audio/ring.ts
+++ b/player/src/audio/ring.ts
@@ -59,11 +59,15 @@ export class Ring {
                     frameCount: first.length,
                 })
 
+               //For some reason this breaks audio... and this is my temporary fix
+               //console.log("frame offset", first.length , "frame count", second.length) to test
+               if (first.length < second.length) {
                 frame.copyTo(second, {
                     planeIndex: i,
                     frameOffset: first.length,
                     frameCount: second.length,
                 })
+              }
             }
         }
 

--- a/player/src/audio/ring.ts
+++ b/player/src/audio/ring.ts
@@ -50,7 +50,9 @@ export class Ring {
                     planeIndex: i,
                     frameCount: count,
                 })
-            } else {
+            //audio seems to be breaking whenever endIndex is 0
+            //this works, without "chopiness" 
+            } else if (startIndex  >=  endIndex && endIndex != 0) {
                 const first = channel.subarray(startIndex)
                 const second = channel.subarray(0, endIndex)
 
@@ -59,15 +61,12 @@ export class Ring {
                     frameCount: first.length,
                 })
 
-               //For some reason this breaks audio... and this is my temporary fix
                //console.log("frame offset", first.length , "frame count", second.length) to test
-               if (first.length < second.length) {
                 frame.copyTo(second, {
                     planeIndex: i,
                     frameOffset: first.length,
                     frameCount: second.length,
                 })
-              }
             }
         }
 


### PR DESCRIPTION
After some time into the audio stream, the audio breaks and an error message is displayed in the console stating that the frame offset exceeds the total frames.  ``
caught RangeError: Failed to execute 'copyTo' on 'AudioData': Frame offset exceeds total frames (1024 >= 1024). ``
This is my proposed solution to the issue.  I have tested and verified that my fix works and the audio now runs smoothly without any break.

I hope it helps :)